### PR TITLE
Add menu-based project selection for start command

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Available commands inside the app:
 
 - `list` – show active projects with total and weekly time.
 - `add <project>` – create a new project entry.
-- `start <project>` – start a 25 minute Pomodoro for the specified project.
+- `start` – select an existing project from a menu and start a 25 minute Pomodoro. You can also specify a project name directly with `start <project>`.
 - `pause` – pause the running timer.
 - `resume` – resume a paused timer.
 - `stop` – stop the timer and record the session.

--- a/pomodoro.py
+++ b/pomodoro.py
@@ -182,6 +182,27 @@ class PomodoroApp(cmd.Cmd):
                 f"- {pid}. {name}: total {format_seconds(total)}, this week {format_seconds(week)}"
             )
 
+    def _choose_project(self) -> str:
+        """Display a menu of projects and return the chosen project name."""
+        projects = self.db.get_active_projects()
+        if not projects:
+            return input("New project name: ").strip()
+
+        print("Choose a project:")
+        for idx, (_, name, _, _) in enumerate(projects, start=1):
+            print(f"{idx}. {name}")
+        print("0. New project")
+
+        while True:
+            choice = input("Select project: ").strip()
+            if choice.isdigit():
+                num = int(choice)
+                if num == 0:
+                    return input("New project name: ").strip()
+                if 1 <= num <= len(projects):
+                    return projects[num - 1][1]
+            print("Invalid selection. Try again.")
+
     def preloop(self):
         self._list_projects()
 
@@ -230,11 +251,10 @@ class PomodoroApp(cmd.Cmd):
             return
         project = arg.strip()
         if not project:
-            project = input("Project name: ").strip()
+            project = self._choose_project()
         if not project:
             print("Project name required.")
             return
-        self._list_projects()
         self._start_pomodoro(project)
 
     def _finish_session(self, reason: str = "finished") -> None:


### PR DESCRIPTION
## Summary
- add `_choose_project` utility to select a project from a menu
- update `do_start` to use the menu when no project name is given
- document new behaviour in README

## Testing
- `python3 -m py_compile pomodoro.py`